### PR TITLE
Don't report fetching as changed file

### DIFF
--- a/tasks/copy_single.yml
+++ b/tasks/copy_single.yml
@@ -34,6 +34,7 @@
       validate_checksum: yes
       fail_on_missing: yes
     delegate_to: "{{ local_ca_workhost }}"
+    changed_when: False
 
   - name: Upload {{ name }} to target node
     when: not local_ca_is_local


### PR DESCRIPTION
It is completely irrelevant for the performance of the role if fetching
the file to the control node changes anything. Therefore ignore this
change note.