### PR TITLE
Refine unique_subject option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ delegated node) CA.
 | `local_ca_mode` | `0640` | Permissions of certificates on the target node |
 | `local_ca_unique_subject` | `True` | Enforce unique CN names |
 
+
+### `local_ca_unique_subject`
+
+The value of the first execution of the role for a given CA is decisive.
+Subsequent runs with different value won't change the value of this
+configuration option. "Upgrading" an existing CA to allow non-unique names has
+to be done manually.
+
 ## How to use this?
 
 This role has to be called with parameters, like so:

--- a/templates/openssl-1.0.cnf.j2
+++ b/templates/openssl-1.0.cnf.j2
@@ -1,103 +1,102 @@
-# This file is managed by ansible (role: local-ca)
 # For use with Easy-RSA 3.0 and OpenSSL 1.0.*
 
-RANDFILE                = $ENV::EASYRSA_PKI/.rnd
+RANDFILE		= $ENV::EASYRSA_PKI/.rnd
 
 ####################################################################
 [ ca ]
-default_ca      = CA_default            # The default ca section
+default_ca	= CA_default		# The default ca section
 
 ####################################################################
 [ CA_default ]
 
-dir             = $ENV::EASYRSA_PKI     # Where everything is kept
-certs           = $dir                  # Where the issued certs are kept
-crl_dir         = $dir                  # Where the issued crl are kept
-database        = $dir/index.txt        # database index file.
-new_certs_dir   = $dir/certs_by_serial  # default place for new certs.
+dir		= $ENV::EASYRSA_PKI	# Where everything is kept
+certs		= $dir			# Where the issued certs are kept
+crl_dir		= $dir			# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+new_certs_dir	= $dir/certs_by_serial	# default place for new certs.
 
-certificate     = $dir/ca.crt           # The CA certificate
-serial          = $dir/serial           # The current serial number
-crl             = $dir/crl.pem          # The current CRL
-private_key     = $dir/private/ca.key   # The private key
-RANDFILE        = $dir/.rand            # private random number file
+certificate	= $dir/ca.crt	 	# The CA certificate
+serial		= $dir/serial 		# The current serial number
+crl		= $dir/crl.pem 		# The current CRL
+private_key	= $dir/private/ca.key	# The private key
+RANDFILE	= $dir/.rand		# private random number file
 
-x509_extensions = basic_exts            # The extentions to add to the cert
+x509_extensions	= basic_exts		# The extentions to add to the cert
 
 # This allows a V2 CRL. Ancient browsers don't like it, but anything Easy-RSA
 # is designed for will. In return, we get the Issuer attached to CRLs.
-crl_extensions  = crl_ext
+crl_extensions	= crl_ext
 
-default_days    = $ENV::EASYRSA_CERT_EXPIRE     # how long to certify for
-default_crl_days= $ENV::EASYRSA_CRL_DAYS        # how long before next CRL
-default_md      = $ENV::EASYRSA_DIGEST          # use public key default MD
-preserve        = no                    # keep passed DN ordering
+default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
+default_crl_days= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
+default_md	= $ENV::EASYRSA_DIGEST		# use public key default MD
+preserve	= no			# keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional
 # and supplied fields are just that :-)
-policy          = policy_anything
+policy		= policy_anything
 unique_subject = {{ "yes" if local_ca_unique_subject else "no" }}
 
 # For the 'anything' policy, which defines allowed DN fields
 [ policy_anything ]
-countryName             = optional
-stateOrProvinceName     = optional
-localityName            = optional
-organizationName        = optional
-organizationalUnitName  = optional
-commonName              = supplied
-name                    = optional
-emailAddress            = optional
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+name			= optional
+emailAddress		= optional
 
 ####################################################################
 # Easy-RSA request handling
 # We key off $DN_MODE to determine how to format the DN
 [ req ]
-default_bits            = $ENV::EASYRSA_KEY_SIZE
-default_keyfile         = privkey.pem
-default_md              = $ENV::EASYRSA_DIGEST
-distinguished_name      = $ENV::EASYRSA_DN
-x509_extensions         = easyrsa_ca    # The extentions to add to the self signed cert
+default_bits		= $ENV::EASYRSA_KEY_SIZE
+default_keyfile 	= privkey.pem
+default_md		= $ENV::EASYRSA_DIGEST
+distinguished_name	= $ENV::EASYRSA_DN
+x509_extensions		= easyrsa_ca	# The extentions to add to the self signed cert
 
 # A placeholder to handle the $EXTRA_EXTS feature:
-#%EXTRA_EXTS%   # Do NOT remove or change this line as $EXTRA_EXTS support requires it
+#%EXTRA_EXTS%	# Do NOT remove or change this line as $EXTRA_EXTS support requires it
 
 ####################################################################
 # Easy-RSA DN (Subject) handling
 
 # Easy-RSA DN for cn_only support:
 [ cn_only ]
-commonName              = Common Name (eg: your user, host, or server name)
-commonName_max          = 64
-commonName_default      = $ENV::EASYRSA_REQ_CN
+commonName		= Common Name (eg: your user, host, or server name)
+commonName_max		= 64
+commonName_default	= $ENV::EASYRSA_REQ_CN
 
 # Easy-RSA DN for org support:
 [ org ]
-countryName                     = Country Name (2 letter code)
-countryName_default             = $ENV::EASYRSA_REQ_COUNTRY
-countryName_min                 = 2
-countryName_max                 = 2
+countryName			= Country Name (2 letter code)
+countryName_default		= $ENV::EASYRSA_REQ_COUNTRY
+countryName_min			= 2
+countryName_max			= 2
 
-stateOrProvinceName             = State or Province Name (full name)
-stateOrProvinceName_default     = $ENV::EASYRSA_REQ_PROVINCE
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= $ENV::EASYRSA_REQ_PROVINCE
 
-localityName                    = Locality Name (eg, city)
-localityName_default            = $ENV::EASYRSA_REQ_CITY
+localityName			= Locality Name (eg, city)
+localityName_default		= $ENV::EASYRSA_REQ_CITY
 
-0.organizationName              = Organization Name (eg, company)
-0.organizationName_default      = $ENV::EASYRSA_REQ_ORG
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= $ENV::EASYRSA_REQ_ORG
 
-organizationalUnitName          = Organizational Unit Name (eg, section)
-organizationalUnitName_default  = $ENV::EASYRSA_REQ_OU
+organizationalUnitName		= Organizational Unit Name (eg, section)
+organizationalUnitName_default	= $ENV::EASYRSA_REQ_OU
 
-commonName                      = Common Name (eg: your user, host, or server name)
-commonName_max                  = 64
-commonName_default              = $ENV::EASYRSA_REQ_CN
+commonName			= Common Name (eg: your user, host, or server name)
+commonName_max			= 64
+commonName_default		= $ENV::EASYRSA_REQ_CN
 
-emailAddress                    = Email Address
-emailAddress_default            = $ENV::EASYRSA_REQ_EMAIL
-emailAddress_max                = 64
+emailAddress			= Email Address
+emailAddress_default		= $ENV::EASYRSA_REQ_EMAIL
+emailAddress_max		= 64
 
 ####################################################################
 # Easy-RSA cert extension handling
@@ -106,9 +105,9 @@ emailAddress_max                = 64
 # dynamically. This core section is left to support the odd usecase where
 # a user calls openssl directly.
 [ basic_exts ]
-basicConstraints        = CA:FALSE
-subjectKeyIdentifier    = hash
-authorityKeyIdentifier  = keyid,issuer:always
+basicConstraints	= CA:FALSE
+subjectKeyIdentifier	= hash
+authorityKeyIdentifier	= keyid,issuer:always
 
 # The Easy-RSA CA extensions
 [ easyrsa_ca ]
@@ -136,5 +135,4 @@ keyUsage = cRLSign, keyCertSign
 
 # issuerAltName=issuer:copy
 authorityKeyIdentifier=keyid:always,issuer:always
-
 


### PR DESCRIPTION
Add imporant note on first roll-out to readme

Use the same template as in the archive. The old template had different
whitespace formatting leading to a huge diff with no information. Fix
this by using the configuration file from the archive with the correct
whitespacing