### PR TITLE
Skip local sudo

### DIFF
--- a/tasks/copy_single.yml
+++ b/tasks/copy_single.yml
@@ -8,33 +8,33 @@
   # * `changed_when`: Override changed_when condition of copy tasks
 
   - name: Create remote directory
-    become: True
+    become: "{{ 'no' if local_ca_is_to_local else 'yes' }}"
     file:
       path: "{{ dest | dirname }}"
       state: directory
-      owner: "{{ local_ca_owner }}"
-      group: "{{ local_ca_group }}"
+      owner: "{{ omit if local_ca_is_to_local_same_user else local_ca_owner }}"
+      group: "{{ omit if local_ca_is_to_local_same_user else local_ca_group }}"
       mode: u+rwx
 
   - name: Copy {{ name }} to node
-    become: True
+    become: "{{ 'no' if local_ca_is_to_local else 'yes' }}"
     when: local_ca_is_local and changed_when is not defined
     copy:
       src: "{{ src }}"
       dest: "{{ dest }}"
-      owner: "{{ local_ca_owner }}"
-      group: "{{ local_ca_group }}"
-      mode: "{{ local_ca_mode }}"
+      owner: "{{ omit if local_ca_is_to_local_same_user else local_ca_owner }}"
+      group: "{{ omit if local_ca_is_to_local_same_user else local_ca_group }}"
+      mode: "{{ omit if local_ca_is_to_local_same_user else local_ca_mode }}"
 
   - name: Copy {{ name }} to node
-    become: True
+    become: "{{ 'no' if local_ca_is_to_local else 'yes' }}"
     when: local_ca_is_local and changed_when is defined
     copy:
       src: "{{ src }}"
       dest: "{{ dest }}"
-      owner: "{{ local_ca_owner }}"
-      group: "{{ local_ca_group }}"
-      mode: "{{ local_ca_mode }}"
+      owner: "{{ omit if local_ca_is_to_local_same_user else local_ca_owner }}"
+      group: "{{ omit if local_ca_is_to_local_same_user else local_ca_group }}"
+      mode: "{{ omit if local_ca_is_to_local_same_user else local_ca_mode }}"
     changed_when: changed_when|bool
 
   - name: Fetch {{ name }} to control node
@@ -50,21 +50,21 @@
 
   - name: Upload {{ name }} to target node
     when: not local_ca_is_local and not ansible_check_mode and changed_when is not defined
-    become: True
+    become: "{{ 'no' if local_ca_is_to_local else 'yes' }}"
     copy:
       src: "{{ local_ca_fetchdir }}/{{ tmpname }}"
       dest: "{{ dest }}"
-      owner: "{{ local_ca_owner }}"
-      group: "{{ local_ca_group }}"
-      mode: "{{ local_ca_mode }}"
+      owner: "{{ omit if local_ca_is_to_local_same_user else local_ca_owner }}"
+      group: "{{ omit if local_ca_is_to_local_same_user else local_ca_group }}"
+      mode: "{{ omit if local_ca_is_to_local_same_user else local_ca_mode }}"
 
   - name: Upload {{ name }} to target node
     when: not local_ca_is_local and not ansible_check_mode and changed_when is defined
-    become: True
+    become: "{{ 'no' if inventory_hostname == 'local' else 'yes' }}"
     copy:
       src: "{{ local_ca_fetchdir }}/{{ tmpname }}"
       dest: "{{ dest }}"
-      owner: "{{ local_ca_owner }}"
-      group: "{{ local_ca_group }}"
-      mode: "{{ local_ca_mode }}"
+      owner: "{{ omit if local_ca_is_to_local_same_user else local_ca_owner }}"
+      group: "{{ omit if local_ca_is_to_local_same_user else local_ca_group }}"
+      mode: "{{ omit if local_ca_is_to_local_same_user else local_ca_mode }}"
     changed_when: changed_when|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,14 @@
     set_fact:
       local_ca_is_local: "{{ local_ca_workhost == 'localhost' }}"
 
+  - name: Check local target
+    set_fact:
+      local_ca_is_to_local: "{{ inventory_hostname == 'local' }}"
+
+  - name: Check local target user
+    set_fact:
+      local_ca_is_to_local_same_user: "{{ local_ca_is_to_local and local_ca_owner == ansible_user_id and local_ca_group == ansible_user_gid }}"
+
   - name: Set work dir
     set_fact:
       workdir: "secrets/pki/{{ local_ca_caname }}"


### PR DESCRIPTION
This commit adds a new workaround that iff:
 * we copy to the controller node and
 * we want the current user and the current group as owner
then we don't use sudo and don't manually set the file ownership.
This is extremely beneficial on platforms where sudo has some
implications (e.g. OSX), because this means we won't use `become` unless
necessary.
